### PR TITLE
Update build_loop.yml

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -17,7 +17,7 @@ jobs:
     
   build:
     needs: secrets
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
       # Uncomment to manually select latest Xcode if needed
       - name: Select Latest Xcode


### PR DESCRIPTION
Endre macos 13 tilbake til macos 12. 

Odd forsøkte å gjøre ting enklere når vi bygde i april, men oppdateringen fra Marion Barker tenker på en annen måte. Dermed må vi endre build_loop.yml dokumentet tilbake til slik det opprinnelig var...!